### PR TITLE
fix compatability with Violentmonkey close #61

### DIFF
--- a/EhTagSyringe.user.js
+++ b/EhTagSyringe.user.js
@@ -23,6 +23,7 @@
 // @resource    ets-prompt       https://raw.githubusercontent.com/Mapaler/EhTagTranslator/master/template/ets-prompt.html?v=42
 // @version     1.3.8
 // @run-at      document-start
+// @inject-into page
 // @grant       unsafeWindow
 // @grant       GM_xmlhttpRequest
 // @grant       GM_getValue
@@ -202,7 +203,7 @@ height: unset;
 #taglist a:hover { z-index: 60; }
 #taglist a:focus { z-index: 50; }
 #taglist a::after{ z-index: -1; }
-#taglist a::before { 
+#taglist a::before {
     z-index: 1;
     white-space:nowrap;
 }`,
@@ -498,7 +499,16 @@ var Aria2 = (function (_isGM, _arrFn, _merge, _format, _isFunction) {
     if (typeof(GM_info)!="undefined")
     {
         pluginVersion = GM_info.script.version.replace(/(^\s*)|(\s*$)/g, "");
-        pluginName = GM_info.script.localizedName || GM_info.script.name_i18n[lang] || GM_info.script.name;
+
+        if (GM_info.script.hasOwnProperty('localizedName')) {
+            pluginName = GM.info.script.localizedName;
+        } else if (GM_info.script.hasOwnProperty('name_i8n')) {
+            pluginName = GM_info.script.name_i18n[lang];
+        } else if (GM_info.script.hasOwnProperty('name')) {
+            pluginName = GM_info.script.name;
+        } else {
+            pluginName = "EhTagSyringe";
+        }
     }
     var rootScope = null;
 

--- a/template/ets-builder-menu.html
+++ b/template/ets-builder-menu.html
@@ -359,7 +359,7 @@
 
     <div class="select-menu-list js-navigation-container">
         <button style="width: 100%;" class="select-menu-item select-menu-action" ng-click="saveCss()">
-            <span class="octicon octicon-book select-menu-item-icon">💉</span>
+            <span class="octicon octicon-book select-menu-item-icon">&#x1F489</span>
             <div class="select-menu-item-text" >保存数据</div>
         </button>
     </div>


### PR DESCRIPTION
两个commit
1. 修复和violentmonkey的兼容性，另外violentmonkey必须加装一个response header modifier来删掉github的csp策略，在commit message里有详情
2. 用Unicode代替emoji，防止在firefox中出现这样乱码
![1](https://user-images.githubusercontent.com/28209092/57830287-a25bfc00-777f-11e9-8bcc-f8f731625c4d.PNG)

另外Violentmonkey的[GM_addStyle](https://violentmonkey.github.io/api/gm/#gm_addstyle)是异步的，所以有一定几率有的时候会不出现按钮。一个办法是直接写一个`addStyle`，可以参考https://github.com/greasemonkey/gm4-polyfill/blob/master/gm4-polyfill.js#L33，我没有动这部分
